### PR TITLE
add examples of Template haskell

### DIFF
--- a/Playground.cabal
+++ b/Playground.cabal
@@ -27,6 +27,7 @@ executable main
                      , template-haskell >= 2.10.0.0
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
+                     , file-embed >= 0.0.10
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -54,6 +55,7 @@ library
                      , template-haskell >= 2.10.0.0
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
+                     , file-embed >= 0.0.10
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -79,5 +81,6 @@ test-suite spec
                      , template-haskell >= 2.10.0.0
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
+                     , file-embed >= 0.0.10
   hs-source-dirs:       src
   default-language:     Haskell2010

--- a/Playground.cabal
+++ b/Playground.cabal
@@ -10,10 +10,10 @@ executable main
   main-is:             Main.hs
   ghc-options:         -Wall -fno-warn-unused-do-bind -fno-warn-type-defaults
   build-depends:       HUnit >= 1.2.5.2
-                     , base-prelude
                      , QuickCheck >= 2.8.1
                      , array >=0.5 && <0.6
                      , base >= 4 && < 5
+                     , base-prelude
                      , bytestring >= 0.10.6.0
                      , containers
                      , diffarray
@@ -24,6 +24,7 @@ executable main
                      , parsec
                      , process >= 1.2.3.0
                      , random >= 1.1
+                     , template-haskell >= 2.10.0.0
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
   hs-source-dirs:      src
@@ -35,10 +36,10 @@ library
   ghc-options:         -Wall -fno-warn-unused-do-bind -fno-warn-type-defaults
   build-depends:       HUnit >= 1.2.5.2
                      , QuickCheck >= 2.8.1
-                     , base-prelude
                      , aeson
                      , array >=0.5 && <0.6
                      , base >= 4 && < 5
+                     , base-prelude
                      , bytestring >= 0.10.6.0
                      , containers
                      , diffarray
@@ -50,6 +51,7 @@ library
                      , parsec
                      , process >= 1.2.3.0
                      , random >= 1.1
+                     , template-haskell >= 2.10.0.0
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
   hs-source-dirs:      src
@@ -61,9 +63,9 @@ test-suite spec
   ghc-options:          -threaded -Wall -fno-warn-unused-do-bind -fno-warn-type-defaults
   build-depends:       HUnit >= 1.2.5.2
                      , QuickCheck >= 2.8.1
-                     , base-prelude
                      , array >=0.5 && <0.6
                      , base >= 4 && < 5
+                     , base-prelude
                      , bytestring >= 0.10.6.0
                      , containers
                      , diffarray
@@ -74,6 +76,7 @@ test-suite spec
                      , parsec
                      , process >= 1.2.3.0
                      , random >= 1.1
+                     , template-haskell >= 2.10.0.0
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
   hs-source-dirs:       src

--- a/Playground.cabal
+++ b/Playground.cabal
@@ -28,6 +28,7 @@ executable main
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
                      , file-embed >= 0.0.10
+                     , aeson
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -82,5 +83,6 @@ test-suite spec
                      , text >= 1.2.1.3
                      , vector >= 0.11.0.0
                      , file-embed >= 0.0.10
+                     , aeson
   hs-source-dirs:       src
   default-language:     Haskell2010

--- a/resources/DecodeTest.json
+++ b/resources/DecodeTest.json
@@ -1,0 +1,6 @@
+{
+  "database": "host=192.16...",
+  "domain":   "super.com",
+  "port":      8080,
+  "apiKey":   "asdfjkl;"
+}

--- a/src/DecodeJsonOnCompile/Definitions.hs
+++ b/src/DecodeJsonOnCompile/Definitions.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+module DecodeJsonOnCompile.Definitions where
+
+import GHC.Generics
+import Data.Aeson
+import Data.FileEmbed (embedFile)
+
+import qualified Data.ByteString.Lazy as BL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+
+import qualified Language.Haskell.TH as TH
+import qualified Language.Haskell.TH.Quote as THQ
+import qualified Language.Haskell.TH.Syntax as THS
+
+data Config = Config
+  { database :: String
+  , domain   :: String
+  , port     :: Int
+  , apiKey   :: String
+  } deriving (Generic, Show, Eq)
+instance ToJSON Config
+instance FromJSON Config
+
+-- NOTE: -XDeriveLift is available for template-haskell-2.11.0.0
+instance THS.Lift Config where
+ lift (Config a b c d) = [| Config $(THS.lift a) $(THS.lift b) $(THS.lift c) $(THS.lift d) |]
+
+config0 :: FilePath -> IO (Either String Config)
+config0 fp = eitherDecode <$> BL.readFile fp
+
+config1 :: Either String Config
+config1 = eitherDecode $ BL.fromStrict $(embedFile "resources/DecodeTest.json")
+-- fp cannot be put as an argument because of GHC stage restriction
+-- config1 fp = eitherDecode $ BL.fromStrict $(embedFile fp)
+
+config2 :: THQ.QuasiQuoter
+config2 = THQ.QuasiQuoter { THQ.quoteExp = quoteHExp
+                           , THQ.quotePat  = undefined
+                           , THQ.quoteType = undefined
+                           , THQ.quoteDec  = undefined
+                           }
+  where
+    s2bl :: String -> BL.ByteString
+    s2bl = BL.fromStrict . TE.encodeUtf8 . T.pack
+    quoteHExp :: String -> TH.ExpQ
+    quoteHExp str = do
+      case eitherDecode (s2bl str) :: Either String Config of
+        Left msg -> fail $ "configFromJSON fails: " ++ msg
+        Right settings -> THS.lift settings
+
+config3 :: FilePath -> TH.ExpQ
+config3 fp = do
+  bl <- TH.runIO $ BL.readFile fp
+  case eitherDecode bl :: Either String Config of
+    Left msg -> fail $ "configFromJSONFile fails: " ++ msg
+    Right settings -> THS.lift settings

--- a/src/DecodeJsonOnCompile/Usage.hs
+++ b/src/DecodeJsonOnCompile/Usage.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+module DecodeJsonOnCompile.Usage where
+
+-- NOTE: need to separate modules because of GHC stage restriction
+import DecodeJsonOnCompile.Definitions
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "json data conversion" $ do
+    it "runtime decode with runtime file read" $ do
+      Right c <- config0 "resources/DecodeTest.json"
+      c `shouldBe`
+        Config { database = "host=192.16..."
+               , domain = "super.com"
+               , port = 8080
+               , apiKey = "asdfjkl;" }
+
+    it "runtime decode with compile time file read" $
+      config1 `shouldBe` Right (
+        Config { database = "host=192.16..."
+               , domain = "super.com"
+               , port = 8080
+               , apiKey = "asdfjkl;" }
+        )
+
+    it "compile time decode as quasiquoter" $
+      [config2| {
+        "database": "host=...",
+        "domain":   "super.com",
+        "port":     8080,
+        "apiKey":   "asdfjkl;"
+      }|] `shouldBe` Config { database = "host=..."
+                            , domain = "super.com"
+                            , port = 8080
+                            , apiKey = "asdfjkl;"
+                            }
+
+    it "compile time decode with compile time file read" $
+      $(config3 "resources/DecodeTest.json") `shouldBe`
+        Config { database = "host=192.16..."
+               , domain = "super.com"
+               , port = 8080
+               , apiKey = "asdfjkl;" }

--- a/src/Extentions/QuasiQuoter.hs
+++ b/src/Extentions/QuasiQuoter.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+module Extentions.QuasiQuoter where
+
+-- Reference: https://wiki.haskell.org/Quasiquotation
+
+import qualified Language.Haskell.TH as TH
+import qualified Language.Haskell.TH.Quote as THQ
+import qualified Language.Haskell.TH.Syntax as THS
+import Text.Parsec
+import Text.Parsec.Language (haskell)
+import Text.Parsec.Token (integer, parens, symbol)
+
+
+---------------------------------------
+-- syntax definition and interpreter --
+
+data HExp = HIntE Integer
+          | HBinOpE HExp HBinOp HExp
+          deriving (Show, Eq)
+
+data HBinOp = HAddO | HSubO | HMulO | HDivO
+           deriving (Show, Eq)
+
+eval :: HExp -> Integer
+eval (HIntE n) = n
+eval (HBinOpE x b y) =
+  (case b of
+    HAddO -> (+)
+    HSubO -> (-)
+    HMulO -> (*)
+    HDivO -> div
+  ) (eval x) (eval y)
+
+
+-------------------
+-- parsec parser --
+
+pHExp :: Parsec String () HExp
+pHExp =
+      HIntE <$> integer'
+  <|> parens' (HBinOpE <$> pHExp <*> pHBinOp <*> pHExp)
+  where
+    parens' = parens haskell
+    integer' = integer haskell
+
+pHBinOp :: Parsec String () HBinOp
+pHBinOp =
+      pure HAddO <* symbol' "+"
+  <|> pure HSubO <* symbol' "-"
+  <|> pure HMulO <* symbol' "*"
+  <|> pure HDivO <* symbol' "/"
+  where
+    symbol' = symbol haskell
+
+doParse :: Monad m => (String, Int, Int) -> String -> m HExp
+doParse (file, line, col) s =
+  case runParser p () "" s of
+    Left err -> fail $ show err
+    Right e  -> return e
+  where
+    p = do
+      setPosition .
+        (`setSourceName` file) .
+        (`setSourceLine` line) .
+        (`setSourceColumn` col) =<< getPosition
+      spaces *> pHExp <* eof
+
+
+----------------------------------------------
+-- define quasiquoter by using above parser --
+
+hexpr :: THQ.QuasiQuoter
+hexpr = THQ.QuasiQuoter { THQ.quoteExp = quoteHExp
+                         , THQ.quotePat  = undefined
+                         , THQ.quoteType = undefined
+                         , THQ.quoteDec  = undefined
+                         }
+
+quoteHExp :: String -> TH.ExpQ
+quoteHExp s = do
+  loc <- TH.location
+  let (line, col) = TH.loc_start loc
+      file = TH.loc_filename loc
+  THS.lift =<< doParse (file, line, col) s
+
+-- NOTE:
+--   `liftData :: Data a => a -> Q Exp` is available from template-haskell-2.11.0.0,
+--   but, currently 2.10.0.0 is used
+
+instance THS.Lift HExp where
+  lift (HIntE i) = [| HIntE $(THS.lift i) |]
+  lift (HBinOpE e0 b e1) = [| HBinOpE $(THS.lift e0) $(THS.lift b) $(THS.lift e1) |]
+
+instance THS.Lift HBinOp where
+  lift HAddO = [| HAddO |]
+  lift HSubO = [| HSubO |]
+  lift HMulO = [| HMulO |]
+  lift HDivO = [| HDivO |]

--- a/src/Extentions/QuasiQuotes.hs
+++ b/src/Extentions/QuasiQuotes.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE QuasiQuotes #-}
+module Extentions.QuasiQuotes (spec) where
+
+import Extentions.QuasiQuoter
+import Test.Hspec
+
+
+spec :: Spec
+spec =
+  describe "\n[hexpr| ... |]" $ do
+    it "[hexpr| ( 1 * (1 / 2)) |] == HBinOpE (HIntE 1) HMulO (... " $
+      [hexpr| ( 1 * (1 / 2)) |] == HBinOpE (HIntE 1) HMulO (HBinOpE (HIntE 1) HDivO (HIntE 2))

--- a/src/Extentions/TemplateHaskell.hs
+++ b/src/Extentions/TemplateHaskell.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Extentions.TemplateHaskell (basicSpec) where
+
+-- Reference: https://wiki.haskell.org/Template_Haskell
+-- NOTE:
+-- - debug splices on ghci:
+--   > :set -ddump-splices
+--   > :load Extentions.TemplateHaskell
+
+-- TODO:
+-- - n tree type declaration and n tree some operation
+
+import Language.Haskell.TH
+import qualified Extentions.TemplateHaskellAvoidStageRestriction as ASR
+import Test.Hspec
+
+basicSpec :: Spec
+basicSpec = do
+  describe "[| ... |] :: Q Exp" $ do
+    it "[| map (\\_ -> 0) [] |] is return (AppE (AppE (VarE 'map) ...)" $ do
+      ex <- runQ [| map (\_ -> 0) [] |] :: IO Exp
+      ex `shouldBe` AppE (AppE (VarE 'map) (LamE [WildP] (LitE (IntegerL 0)))) (ListE [])
+
+  describe "\n'f and ''T" $ do
+    it "'map :: Name" $ do
+      'map `shouldBe` ('map :: Name)
+    it "''String :: Name" $ do
+      ''String `shouldBe` (''String :: Name)
+
+  describe "\n$( ... ) where ... must be Q Exp " $ do
+    it "$(return (LitE (StringL \"foo\"))) == \"foo\"" $ do
+      $(return (LitE (StringL "foo"))) == "foo"
+    it "$([| something |]) == something" $ do
+      $([| 0 + 1 + 2 |]) == 0 + 1 + 2
+    it "$x is $(x) where x :: Q Exp" $ do
+      $((\x -> [| $x |]) (return (LitE (StringL "foo")))) == "foo"
+      &&
+      $((\x -> [| $(x) |]) (return (LitE (StringL "foo")))) == "foo"
+
+  describe "\nQ Exp -> Q Exp" $ do
+    it "\\e -> [| ($e, $e) |]" $ do
+      $((\e -> [| ($e, $e) |]) (return (LitE (StringL "foo")))) == ("foo", "foo")
+
+  describe "\nGHC stage restriction" $ do
+    it "ASR.foo is okay but _foo is wrong" $ do
+      let _foo = LitE (StringL "foo") :: Exp
+      -- $(return _foo) == "foo" -- not allowed because of GHC stage restriction
+      $(return ASR.foo) == "foo"

--- a/src/Extentions/TemplateHaskell.hs
+++ b/src/Extentions/TemplateHaskell.hs
@@ -7,12 +7,10 @@ module Extentions.TemplateHaskell (basicSpec) where
 --   > :set -ddump-splices
 --   > :load Extentions.TemplateHaskell
 
--- TODO:
--- - n tree type declaration and n tree some operation
-
 import Language.Haskell.TH
 import qualified Extentions.TemplateHaskellAvoidStageRestriction as ASR
 import Test.Hspec
+import Extentions.TemplateHaskellTupleGetter (tupleGetter)
 
 basicSpec :: Spec
 basicSpec = do
@@ -46,3 +44,7 @@ basicSpec = do
       let _foo = LitE (StringL "foo") :: Exp
       -- $(return _foo) == "foo" -- not allowed because of GHC stage restriction
       $(return ASR.foo) == "foo"
+
+  describe "\ntupleGetter" $ do
+    it "$(tupleGetter 7 4) (0, 1, 2, 3, 4, 5, 6) == 4" $ do
+      $(tupleGetter 7 4) (0, 1, 2, 3, 4, 5, 6) == 4

--- a/src/Extentions/TemplateHaskellAvoidStageRestriction.hs
+++ b/src/Extentions/TemplateHaskellAvoidStageRestriction.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE TemplateHaskell #-}
+module Extentions.TemplateHaskellAvoidStageRestriction (foo) where
+
+import Language.Haskell.TH
+
+foo :: Exp
+foo = LitE (StringL "foo")

--- a/src/Extentions/TemplateHaskellTupleGetter.hs
+++ b/src/Extentions/TemplateHaskellTupleGetter.hs
@@ -1,0 +1,9 @@
+module Extentions.TemplateHaskellTupleGetter where
+
+import Control.Monad
+import Language.Haskell.TH
+
+tupleGetter :: Int -> Int -> Q Exp
+tupleGetter n i = do
+  vars <- replicateM n (newName "_x") -- prefix underbar to avoid unused variable warning
+  return $ LamE [TupP (map VarP vars)] (VarE (vars !! i))

--- a/src/SpecMain.hs
+++ b/src/SpecMain.hs
@@ -23,6 +23,7 @@ import qualified Uva.P10084 as P10084
 import FloatingPointNumber
 import StringConversions
 import qualified Extentions.TemplateHaskell as ETH
+import qualified Extentions.QuasiQuotes as EQQ
 
 main :: IO ()
 main = hspec $ do
@@ -49,3 +50,4 @@ main = hspec $ do
   describe "FloatingPointNumber" $ FloatingPointNumber.spec
   describe "StringConversions" $ StringConversions.spec
   describe "TemplateHaskell" $ ETH.basicSpec
+  describe "QuasiQuotes" $ EQQ.spec

--- a/src/SpecMain.hs
+++ b/src/SpecMain.hs
@@ -22,6 +22,7 @@ import Kopt
 import qualified Uva.P10084 as P10084
 import FloatingPointNumber
 import StringConversions
+import qualified Extentions.TemplateHaskell as ETH
 
 main :: IO ()
 main = hspec $ do
@@ -47,3 +48,4 @@ main = hspec $ do
   describe "P10084" $ P10084.spec
   describe "FloatingPointNumber" $ FloatingPointNumber.spec
   describe "StringConversions" $ StringConversions.spec
+  describe "TemplateHaskell" $ ETH.basicSpec

--- a/src/SpecMain.hs
+++ b/src/SpecMain.hs
@@ -24,6 +24,7 @@ import FloatingPointNumber
 import StringConversions
 import qualified Extentions.TemplateHaskell as ETH
 import qualified Extentions.QuasiQuotes as EQQ
+import qualified DecodeJsonOnCompile.Usage
 
 main :: IO ()
 main = hspec $ do
@@ -51,3 +52,4 @@ main = hspec $ do
   describe "StringConversions" $ StringConversions.spec
   describe "TemplateHaskell" $ ETH.basicSpec
   describe "QuasiQuotes" $ EQQ.spec
+  describe "DecodeJsonOnCompile.Usage" $ DecodeJsonOnCompile.Usage.spec


### PR DESCRIPTION
spec output is as below:

```
[| ... |] :: Q Exp
  [| map (\_ -> 0) [] |] is return (AppE (AppE (VarE 'map) ...)

'f and ''T
  'map :: Name
  ''String :: Name

$( ... ) where ... must be Q Exp 
  $(return (LitE (StringL "foo"))) == "foo"
  $([| something |]) == something
  $x is $(x) where x :: Q Exp

Q Exp -> Q Exp
  \e -> [| ($e, $e) |]

GHC stage restriction
  ASR.foo is okay but _foo is wrong

tupleGetter
  $(tupleGetter 7 4) (0, 1, 2, 3, 4, 5, 6) == 4
```