### PR TITLE
use hiogawa/haskell:playground instead of fpco/stack-build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "2"
 
 services:
   test:
-    image: fpco/stack-build
-    command: stack build --test
+    image: hiogawa/haskell:playground
+    command: bash -c "stack setup && stack build --test"
     working_dir: /app
     volumes:
       - ./Main.hs:/app/Main.hs


### PR DESCRIPTION
I addresed https://github.com/hi-ogawa/haskell_playground/issues/26.
I made my own stack image https://hub.docker.com/r/hiogawa/haskell/, whose size is about 400MB.